### PR TITLE
Feat/4 typeahead single select

### DIFF
--- a/packages/typeahead/README.md
+++ b/packages/typeahead/README.md
@@ -18,6 +18,8 @@ An example key-value structure that you can pass in could look something like th
 | options | `object`  | An object of key-value pairs. The key can be any valid JavaScript object key name, while the value should be a `String` or `Number` | `{}` |
 | value   | `string`  | A comma-separated list of the keys selected in the typeahead. | `""` |
 | name    | `string`  | The field's name; it should map to a data property in your Foundry application. | `""` |
+| single  | `boolean` | A flag that tells the component to work in single mode. | `false` |
+
 
 ## CSS Variables
 

--- a/packages/typeahead/lib/typeahead.js
+++ b/packages/typeahead/lib/typeahead.js
@@ -59,7 +59,13 @@ export default class Typeahead extends LitElement {
       flex: 0 1 auto;
       padding: .25em .5em;
       margin-right: .5em;
+    }
 
+    :host(:focus-within) .typeahead__selected--single {
+      display: none;
+    }
+
+    :host .typeahead__selected--multi {
       color: var(--typeahead-input-selected-color);
       background: var(--typeahead-input-selected-background);
       border: var(--typeahead-input-selected-border);
@@ -156,7 +162,7 @@ export default class Typeahead extends LitElement {
     }
   `];
 
-  @property()
+  @property({type: String})
   name = "";
 
   @property({reflect: true})
@@ -247,33 +253,39 @@ export default class Typeahead extends LitElement {
     } else
       return html`<span class="typeahead__no-matches">No matches</span>`;
   }
+
+  _renderSelectedOptions(key) {
+    return html`
+      <span class="typeahead__selected typeahead__selected--multi">
+        <span>${this.options[key]}</span>
         <button
-          @click="${this._onOptionClicked}"
-          data-option-key="${key}">
-          ${this.options[key]}
+          data-option-key="${key}"
+          @click="${this._onOptionClicked}">
+          &times;
         </button>
-      </li>
-    `);
+      </span>
+    `;
+  }
+
+  _renderSingleOption(key) {
+    return html`
+      <span class="typeahead__selected typeahead__selected--single">
+        ${this.options[key]}
+      </span>
+    `
   }
 
   render() {
-    const selectedItems = this._selected.map(key =>
-      html`
-        <span class="typeahead__selected">
-          <span>${this.options[key]}</span>
-          <button
-            data-option-key="${key}"
-            @click="${this._onOptionClicked}">
-            &times;
-          </button>
-        </span>
-    `);
+    const selectedItems = (this.single)
+      ? this._selected.map((key) => this._renderSingleOption(key))
+      : this._selected.map((key) => this._renderSelectedOptions(key));
 
     return html`
       <div class="typeahead__input">
         ${selectedItems}
         <pouch-typeahead-query
           name="${this.name}.query"
+          .value=${this._query}
           @keyup="${this._onUpdateQuery}" />
       </div>
       <ul class="typeahead__options" part="options">
@@ -310,6 +322,10 @@ class TypeaheadQuery extends LitElement {
 
   @property()
   name = '';
+
+  reset() {
+    this.shadowRoot.querySelector('input').value = '';
+  }
 
   onChange(evt) {
     this.value = evt.target.value;

--- a/packages/typeahead/lib/typeahead.js
+++ b/packages/typeahead/lib/typeahead.js
@@ -165,6 +165,9 @@ export default class Typeahead extends LitElement {
   @property({type: Object})
   options = {};
 
+  @property({type: Boolean})
+  single = false;
+
   @state()
   _query = '';
 
@@ -189,11 +192,18 @@ export default class Typeahead extends LitElement {
     else
       this._addSelection(optionKey);
 
+    if (this.single)
+      this.shadowRoot
+        .querySelector('pouch-typeahead-query')
+        .reset();
+
     this._notifyOfChange();
   }
 
   _addSelection(optionKey) {
-    this.value = [...this._selected, optionKey].join(',');
+    this.value = (this.single) 
+      ? [optionKey].join(',')
+      : [...this._selected, optionKey].join(',');
   }
 
   _removeSelection(optionKey) {

--- a/packages/typeahead/lib/typeahead.js
+++ b/packages/typeahead/lib/typeahead.js
@@ -139,6 +139,21 @@ export default class Typeahead extends LitElement {
       background: var(--typeahead-option-hover-background);
       /* Hovered item background variable */
     }
+
+    :host .typeahead__no-matches {
+      display: block;
+      width: 100%;
+      padding: .25em 1em;
+
+      font-size: 1em;
+      line-height: 1.4em;
+      font-style: italic;
+
+      color: var(--typeahead-option-color);
+      background: var(--typeahead-option-background);
+      border: var(--typeahead-option-border);
+      font-family: var(--typeahead-option-font-family);
+    }
   `];
 
   @property()
@@ -207,10 +222,21 @@ export default class Typeahead extends LitElement {
         }), {})
       : this.options;
 
-    return Object.keys(queriedOptions).map(key => html`
-      <li
-        class="typeahead__option"
-        ?aria-selected="${this._selected.includes(key)}">
+    if (Object.keys(queriedOptions).length) {
+      return Object.keys(queriedOptions).map(key => html`
+        <li
+          class="typeahead__option"
+          ?aria-selected="${this._selected.includes(key)}">
+          <button
+            @click="${this._onOptionClicked}"
+            data-option-key="${key}">
+            ${this.options[key]}
+          </button>
+        </li>
+      `);
+    } else
+      return html`<span class="typeahead__no-matches">No matches</span>`;
+  }
         <button
           @click="${this._onOptionClicked}"
           data-option-key="${key}">

--- a/storybook/stories/Typeahead.stories.mdx
+++ b/storybook/stories/Typeahead.stories.mdx
@@ -8,11 +8,15 @@ import Typeahead from "@component-pouch/typeahead";
 
 export const Template = ({ options, value }) => html`
   <form>
-    <pouch-typeahead .options=${options} .value="${value}" />
+    <pouch-typeahead
+      .options=${options}
+      .value="${value}"
+      ?single="${true}"
+      @change="${(e) => console.info(e.target.value)}" />
   </form>
 `;
 
-export const AllSelectedTemplate = ({ options, value }) => html`
+export const MultiTemplate = ({ options, value }) => html`
   <form>
     <pouch-typeahead
       .options=${options}
@@ -41,6 +45,7 @@ An example key-value structure that you can pass in could look something like th
 | options | `object`  | An object of key-value pairs. The key can be any valid JavaScript object key name, while the value should be a `String` or `Number` | `{}` |
 | value   | `string`  | A comma-separated list of the keys selected in the typeahead. | `""` |
 | name    | `string`  | The field's name; it should map to a data property in your Foundry application. | `""` |
+| single  | `boolean` | A flag that tells the component to work in single mode. | `false` |
 
 ## CSS Variables
 
@@ -88,13 +93,13 @@ An example key-value structure that you can pass in could look something like th
 ### The typeahead
 
 <Canvas>
-  <Story name="Default" args={{
+  <Story name="Single-select" args={{
     options: {
       tag1: "Tag One",
       tag2: "Tag 2: Tag Harder",
       tag3: "Tag Hard With a Vengeance"
     },
-    value: ""
+    value: "tag2"
   }}>
     {Template.bind({})}
   </Story>
@@ -103,7 +108,7 @@ An example key-value structure that you can pass in could look something like th
 ### The typeahead, with selected options
 
 <Canvas>
-  <Story name="With selected options" args={{
+  <Story name="Multi-select" args={{
     options: {
       tag1: "Tag One",
       tag2: "Tag 2: Tag Harder",
@@ -111,6 +116,6 @@ An example key-value structure that you can pass in could look something like th
     },
     value: "tag1,tag2"
   }}>
-    {AllSelectedTemplate.bind({})}
+    {MultiTemplate.bind({})}
   </Story>
 </Canvas>


### PR DESCRIPTION
## Intent

This changeset updates the Typeahead component to have a single-select mode. It also adds a state for the list of options, for when there are no options that match the searched-for query.

I went back and forth on if single- or multi-select should be the default. This can be fairly easily changed down the line if need be.

## Related Issues
* Resolves #4 